### PR TITLE
fix v2 explorer

### DIFF
--- a/src/__tests__/data/sync/ToEA6kVVodfRW2DuuMjPPMsLLukY4EsScxdHYJkTtdopPD5Z5t9gpB2zEwpschy7rFzTqxQCXQFUBnxT5MAnfkNT4dkWqtHPE2L7bG7GC24XnLy.json
+++ b/src/__tests__/data/sync/ToEA6kVVodfRW2DuuMjPPMsLLukY4EsScxdHYJkTtdopPD5Z5t9gpB2zEwpschy7rFzTqxQCXQFUBnxT5MAnfkNT4dkWqtHPE2L7bG7GC24XnLy.json
@@ -22,13 +22,15 @@
         "output_index": 0,
         "value": "400000000",
         "address": "DGbtmZaPy9ND8aJNBAmvqPiGE3BdJA6WaS",
-        "script_hex": "76a9147dbac9f9ffe7bc4a251361d1dc2f831f267149c988ac"
+        "script_hex": "76a9147dbac9f9ffe7bc4a251361d1dc2f831f267149c988ac",
+        "output_hash": "983a4839c7562a17d64568fceba6972388e425d92cb5789a07a3f21a64a0daa9"
       },
       {
         "output_index": 1,
         "value": "7488663027",
         "address": "DG9CnHbHnRCK2hMykApaa1m4jmAgKeSiB8",
-        "script_hex": "76a91478ae9815177d6b7cfc200f69b87ef1fc55a01c4c88ac"
+        "script_hex": "76a91478ae9815177d6b7cfc200f69b87ef1fc55a01c4c88ac",
+        "output_hash": "983a4839c7562a17d64568fceba6972388e425d92cb5789a07a3f21a64a0daa9"
       }
     ],
     "fees": 22826,

--- a/src/__tests__/data/sync/XSTpb6G8xAzX1fqbWuzTSrcwqtvtEcnVinz7EtjJ6rBxmKmJ4XWSrTbNhvabfe4FXWc7cyUUxwgzsJDFeubQEx1dZPvMncd7LycUhXSShHikr8AN.json
+++ b/src/__tests__/data/sync/XSTpb6G8xAzX1fqbWuzTSrcwqtvtEcnVinz7EtjJ6rBxmKmJ4XWSrTbNhvabfe4FXWc7cyUUxwgzsJDFeubQEx1dZPvMncd7LycUhXSShHikr8AN.json
@@ -23,13 +23,15 @@
         "output_index": 0,
         "value": "1000000",
         "address": "SH3VuitYDAQVQ8bNJbjUF2SZKVDM7e1UwA",
-        "script_hex": "76a914d1615ceb1e2296f614ceaf134e2b6866426fac0288ac"
+        "script_hex": "76a914d1615ceb1e2296f614ceaf134e2b6866426fac0288ac",
+        "output_hash": "9cac32c8f90da72e19cbfd2a9818cd8c44ce52128c762cd29828798aa1d94b8b"
       },
       {
         "output_index": 1,
         "value": "3137707",
         "address": "SM6jgmtwyBTp2iyLVDzYNFrReA8tuyPYGx",
-        "script_hex": "76a914fdde9d3ed221aed5b0aaef59927e2e1122b51db088ac"
+        "script_hex": "76a914fdde9d3ed221aed5b0aaef59927e2e1122b51db088ac",
+        "output_hash": "9cac32c8f90da72e19cbfd2a9818cd8c44ce52128c762cd29828798aa1d94b8b"
       }
     ],
     "fees": 22826,

--- a/src/__tests__/data/sync/v4PKUB8jAMVY8DsF9CrC5pT4kn1rsHtJY1ehtLSMemakWdMHHwdF5tsQXqQWov93ngSX1GUc1y7x91obdRtu9Bpyk3vqMWKnU9QLpYEjuVqLJy9T.json
+++ b/src/__tests__/data/sync/v4PKUB8jAMVY8DsF9CrC5pT4kn1rsHtJY1ehtLSMemakWdMHHwdF5tsQXqQWov93ngSX1GUc1y7x91obdRtu9Bpyk3vqMWKnU9QLpYEjuVqLJy9T.json
@@ -23,13 +23,15 @@
         "output_index": 0,
         "value": "200000000",
         "address": "RMAFS9VhcjEHzsDE81QG4vZepLCe8dku9H",
-        "script_hex": "76a9148251661ceecca8225189f2ab0dd3c304283d5be588ac"
+        "script_hex": "76a9148251661ceecca8225189f2ab0dd3c304283d5be588ac",
+        "output_hash": "8462421e3b0d6e49164fee274e02ca451924da5b3a0d26248134c683408968f6"
       },
       {
         "output_index": 1,
         "value": "365988660",
         "address": "RFUcrjRSAkZcbp8fHBtt3EsGJJURApY6u5",
-        "script_hex": "76a91443fa03e6dd61231a4d16e7f091662de4ebc5b9b188ac"
+        "script_hex": "76a91443fa03e6dd61231a4d16e7f091662de4ebc5b9b188ac",
+        "output_hash": "8462421e3b0d6e49164fee274e02ca451924da5b3a0d26248134c683408968f6"
       }
     ],
     "fees": 2486,

--- a/src/explorer/ledgerexplorer.ts
+++ b/src/explorer/ledgerexplorer.ts
@@ -160,7 +160,7 @@ class LedgerExplorer extends EventEmitter implements IExplorer {
 
       tx.outputs.forEach((output) => {
         // eslint-disable-next-line @typescript-eslint/camelcase,no-param-reassign
-        output.output_hash = tx.id;
+        output.output_hash = tx.hash;
       });
     });
 

--- a/src/storage/mock.ts
+++ b/src/storage/mock.ts
@@ -24,8 +24,8 @@ class Mock implements IStorage {
     return tx;
   }
 
-  async getTx(address: string, id: string) {
-    const index = `${address}-${id}`;
+  async getTx(address: string, hash: string) {
+    const index = `${address}-${hash}`;
     return this.primaryIndex[index];
   }
 
@@ -103,7 +103,7 @@ class Mock implements IStorage {
 
       // clean
       const indexAddress = tx.address;
-      const index = `${indexAddress}-${tx.id}`;
+      const index = `${indexAddress}-${tx.hash}`;
 
       delete this.primaryIndex[index];
       delete this.unspentUtxos[indexAddress];

--- a/src/storage/mock.ts
+++ b/src/storage/mock.ts
@@ -40,7 +40,7 @@ class Mock implements IStorage {
 
     txs.forEach((tx) => {
       const indexAddress = tx.address;
-      const index = `${indexAddress}-${tx.id}`;
+      const index = `${indexAddress}-${tx.hash}`;
 
       // we reject already seen tx and tx pendings
       if (this.primaryIndex[index] || !tx.block) {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,5 +1,4 @@
 export interface TX {
-  id: string;
   hash: string;
   account: number;
   index: number;
@@ -40,7 +39,7 @@ export interface IStorage {
   appendTxs(txs: TX[]): Promise<number>;
   getAddressUnspentUtxos(address: Address): Promise<Output[]>;
   getLastTx(txFilter: { account?: number; index?: number }): Promise<TX | undefined>;
-  getTx(address: string, id: string): Promise<TX | undefined>;
+  getTx(address: string, hash: string): Promise<TX | undefined>;
   getUniquesAddresses(addressesFilter: { account?: number; index?: number }): Promise<Address[]>;
   removeTxs(txsFilter: { account: number; index: number }): Promise<void>;
   export(): Promise<TX[]>;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,5 +1,6 @@
 export interface TX {
   id: string;
+  hash: string;
   account: number;
   index: number;
   block: Block;


### PR DESCRIPTION
As the v2 explorer return transaction json doesn't include the field "id", we use the "hash" field instead, so that the project is compatible with both v2 and v3